### PR TITLE
Added NewProtectorFromBytes wrapper

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -15,9 +15,13 @@ func newLine() io.Reader {
 func GenerateV1PSK() io.Reader {
 	psk := make([]byte, 32)
 	rand.Read(psk)
+
+	return bytesToV1Psk(psk)
+}
+
+func bytesToV1Psk(psk []byte) io.Reader {
 	hexPsk := make([]byte, len(psk)*2)
 	hex.Encode(hexPsk, psk)
-
 	// just a shortcut to NewReader
 	nr := func(b []byte) io.Reader {
 		return bytes.NewReader(b)

--- a/protector.go
+++ b/protector.go
@@ -24,6 +24,10 @@ func NewProtector(input io.Reader) (ipnet.Protector, error) {
 	}, nil
 }
 
+func NewProtectorFromBytes(input []byte) (ipnet.Protector, error) {
+    return NewProtector(bytesToV1Psk(input))
+}
+
 type protector struct {
 	psk         *[32]byte
 	fingerprint []byte


### PR DESCRIPTION
Added function `NewProtectorFromBytes()` that accepts a byte slice, creates a v1psk out of it, then uses the v1psk to create a `Protector`. This makes it easy for implementations to pass their own random psk to create a `Protector` without having to format the corresponding the v1psk themselves.

I implemented this in the way that seemed to make the most sense, and didn't include any tests because the important bits were already tested. None of the changes should break anything, I simply modularized the code a bit more and added this function. However, let me know if there's something I should add/change (e.g. tests, function names).

Thanks!