### PR TITLE
gx: update go-multihash

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-2.3.3: QmZD8G2r3U36AhJs9PoDHfUTx5XtNqarmfbWw2DS9K9JVg
+2.3.4: QmXduVyMCsR4bUbRxvc9oi8PJJFm4hyoisYHhUzCcTnfUS

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
   "gxDependencies": [
     {
       "author": "Kubuxu",
-      "hash": "QmTAR7vrwFqunUjmieAewdfvdQXYUptRPNDpuAEEH9ihgW",
+      "hash": "QmVenqH1JiGkodjGZAS9NaEXdkZpMQQxM8WT6yQ21mPr9u",
       "name": "go-libp2p-dummy-conn",
-      "version": "0.2.6"
+      "version": "0.2.7"
     },
     {
       "author": "libp2p",
-      "hash": "QmauYrW3kDcfZwUuqjyDCSTyaicL8tvo3a7VkAVgAEes96",
+      "hash": "QmXcN1kXchSvodd2MGypWXXirXk7GigQ7WVyWGYpukag6J",
       "name": "go-libp2p-interface-pnet",
-      "version": "2.1.3"
+      "version": "2.1.4"
     },
     {
       "author": "whyrusleeping",
@@ -44,6 +44,6 @@
   "license": "MIT",
   "name": "go-libp2p-pnet",
   "releaseCmd": "git commit -a -m \"gx release $VERSION\"",
-  "version": "2.3.3"
+  "version": "2.3.4"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-peer/pull/20
- https://github.com/libp2p/go-libp2p-secio/pull/23
- https://github.com/multiformats/go-multiaddr/pull/61
- https://github.com/multiformats/go-multiaddr-net/pull/33
- https://github.com/whyrusleeping/iptb/pull/37
- https://github.com/whyrusleeping/mafmt/pull/7
- https://github.com/libp2p/go-libp2p-peerstore/pull/18
- https://github.com/ipfs/go-ipfs-util/pull/6
- https://github.com/libp2p/go-libp2p-transport/pull/25
- https://github.com/libp2p/go-peerstream/pull/19
- https://github.com/libp2p/go-libp2p-loggables/pull/14
- https://github.com/libp2p/go-tcp-transport/pull/17
- https://github.com/libp2p/go-maddr-filter/pull/4
- https://github.com/libp2p/go-ws-transport/pull/28
- https://github.com/libp2p/go-addr-util/pull/9
- https://github.com/ipfs/go-cid/pull/39
- https://github.com/libp2p/go-testutil/pull/15
- https://github.com/libp2p/go-libp2p-interface-conn/pull/4
- https://github.com/libp2p/go-libp2p-interface-pnet/pull/6
- https://github.com/libp2p/go-libp2p-conn/pull/21
- https://github.com/libp2p/go-libp2p-net/pull/15
- https://github.com/libp2p/go-libp2p-metrics/pull/7
- https://github.com/libp2p/go-libp2p-interface-connmgr/pull/2
- https://github.com/libp2p/go-libp2p-host/pull/10
- https://github.com/libp2p/go-libp2p-swarm/pull/46
- https://github.com/libp2p/go-libp2p-nat/pull/4
- https://github.com/libp2p/go-libp2p-netutil/pull/16
- https://github.com/libp2p/go-libp2p-blankhost/pull/7
- https://github.com/libp2p/go-libp2p-circuit/pull/24
- https://github.com/multiformats/go-multiaddr-dns/pull/6
- https://github.com/libp2p/go-libp2p/pull/251
- https://github.com/libp2p/go-libp2p-record/pull/7
- https://github.com/libp2p/go-libp2p-kbucket/pull/16
- https://github.com/libp2p/go-libp2p-routing/pull/19
- https://github.com/libp2p/go-libp2p-kad-dht/pull/105
- https://github.com/jbenet/hang-fds/pull/2
- https://github.com/libp2p/go-floodsub/pull/51
- https://github.com/ipfs/go-block-format/pull/9
- https://github.com/ipfs/go-ipld-format/pull/30
- https://github.com/ipfs/go-ipld-cbor/pull/31
- https://github.com/libp2p/go-libp2p-dummy-conn/pull/5


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace