### PR TITLE
wrap net conns, not transport conns

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-2.3.7: QmSGoP33Ufev1UDsUuHco8rfhVTzxfq6smXhwhN16c5CWd
+3.0.0: QmRHCy6EKtr6uKBhEt6AmvScH87mHSgKcHocbv9djjaqwQ

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   "license": "MIT",
   "name": "go-libp2p-pnet",
   "releaseCmd": "git commit -a -m \"gx release $VERSION\"",
-  "version": "2.3.7"
+  "version": "3.0.0"
 }
 

--- a/package.json
+++ b/package.json
@@ -9,16 +9,10 @@
   },
   "gxDependencies": [
     {
-      "author": "Kubuxu",
-      "hash": "QmQVrq4tXJvpoDTRFxLrfrx9N8NYjTMjTgNEzWTMcKpW6k",
-      "name": "go-libp2p-dummy-conn",
-      "version": "0.2.10"
-    },
-    {
       "author": "libp2p",
-      "hash": "Qmd3oYWVLCVWryDV6Pobv6whZcvDXAHqS3chemZ658y4a8",
+      "hash": "QmW7Ump7YyBMr712Ta3iEVh3ZYcfVvJaPryfbCnyE826b4",
       "name": "go-libp2p-interface-pnet",
-      "version": "2.1.7"
+      "version": "3.0.0"
     },
     {
       "author": "whyrusleeping",

--- a/protector.go
+++ b/protector.go
@@ -3,9 +3,9 @@ package pnet
 import (
 	"fmt"
 	"io"
+	"net"
 
 	ipnet "github.com/libp2p/go-libp2p-interface-pnet"
-	tconn "github.com/libp2p/go-libp2p-transport"
 )
 
 var _ ipnet.Protector = (*protector)(nil)
@@ -33,7 +33,7 @@ type protector struct {
 	fingerprint []byte
 }
 
-func (p protector) Protect(in tconn.Conn) (tconn.Conn, error) {
+func (p protector) Protect(in net.Conn) (net.Conn, error) {
 	return newPSKConn(p.psk, in)
 }
 func (p protector) Fingerprint() []byte {

--- a/psk_conn.go
+++ b/psk_conn.go
@@ -4,10 +4,10 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"io"
+	"net"
 
 	salsa20 "github.com/davidlazar/go-crypto/salsa20"
 	ipnet "github.com/libp2p/go-libp2p-interface-pnet"
-	tconn "github.com/libp2p/go-libp2p-transport"
 	mpool "github.com/libp2p/go-msgio/mpool"
 )
 
@@ -20,7 +20,7 @@ var (
 )
 
 type pskConn struct {
-	tconn.Conn
+	net.Conn
 	psk *[32]byte
 
 	writeS20 cipher.Stream
@@ -73,9 +73,9 @@ func (c *pskConn) Write(in []byte) (int, error) {
 	return c.Conn.Write(out) // send
 }
 
-var _ tconn.Conn = (*pskConn)(nil)
+var _ net.Conn = (*pskConn)(nil)
 
-func newPSKConn(psk *[32]byte, insecure tconn.Conn) (tconn.Conn, error) {
+func newPSKConn(psk *[32]byte, insecure net.Conn) (net.Conn, error) {
 	if insecure == nil {
 		return nil, errInsecureNil
 	}

--- a/psk_conn_test.go
+++ b/psk_conn_test.go
@@ -4,19 +4,14 @@ import (
 	"bytes"
 	"context"
 	"math/rand"
+	"net"
 	"testing"
-
-	dconn "github.com/libp2p/go-libp2p-dummy-conn"
-	tconn "github.com/libp2p/go-libp2p-transport"
 )
 
 var testPSK = [32]byte{} // null bytes are as good test key as any other key
 
-func setupPSKConns(ctx context.Context, t *testing.T) (tconn.Conn, tconn.Conn) {
-	conn1, conn2, err := dconn.NewDummyConnPair()
-	if err != nil {
-		t.Fatal(err)
-	}
+func setupPSKConns(ctx context.Context, t *testing.T) (net.Conn, net.Conn) {
+	conn1, conn2 := net.Pipe()
 
 	psk1, err := newPSKConn(&testPSK, conn1)
 	if err != nil {
@@ -37,14 +32,21 @@ func TestPSKSimpelMessges(t *testing.T) {
 	msg1 := []byte("hello world")
 	out1 := make([]byte, len(msg1))
 
-	_, err := psk1.Write(msg1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	wch := make(chan error)
+	go func() {
+		_, err := psk1.Write(msg1)
+		wch <- err
+	}()
 	n, err := psk2.Read(out1)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	err = <-wch
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if n != len(out1) {
 		t.Fatalf("expected to read %d bytes, read: %d", len(out1), n)
 	}
@@ -68,10 +70,11 @@ func TestPSKFragmentation(t *testing.T) {
 
 	out := make([]byte, 100)
 
-	_, err = psk1.Write(in)
-	if err != nil {
-		t.Fatal(err)
-	}
+	wch := make(chan error)
+	go func() {
+		_, err := psk1.Write(in)
+		wch <- err
+	}()
 
 	for i := 0; i < 10; i++ {
 		_, err = psk2.Read(out)
@@ -79,5 +82,10 @@ func TestPSKFragmentation(t *testing.T) {
 			t.Fatalf("input and output are not the same")
 		}
 		in = in[100:]
+	}
+
+	err = <-wch
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
We now "protect" below the transport layer. Implements modified interface: https://github.com/libp2p/go-libp2p-interface-pnet/pull/9

Also, make the tests work without the dummy conn package (one fewer deps).

DO NOT MERGE (yet)
Part of: libp2p/go-libp2p#297