### PR TITLE
switch to go-buffer-pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,6 @@
       "version": "3.0.0"
     },
     {
-      "author": "whyrusleeping",
-      "hash": "QmWBug6eBS7AxRdCDVuSY5CnSit7cS2XnPFYJWqWDumhCG",
-      "name": "go-msgio",
-      "version": "0.0.3"
-    },
-    {
       "author": "multiformats",
       "hash": "QmewJ1Zp9Hwz5HcMd7JYjhLXwvEHTL2UBCCz3oLt1E2N5z",
       "name": "go-multicodec",
@@ -31,6 +25,12 @@
       "hash": "QmNi5J1mEQKAKWbPRBEMKKYVNok9EN4MsGM4YUqPvraPEX",
       "name": "go-crypto-dav",
       "version": "0.2.2"
+    },
+    {
+      "author": "Stebalien",
+      "hash": "QmUQy76yspPa3fRyY3GzXFTg9n8JVwFru6ue3KFRt4MeTw",
+      "name": "go-buffer-pool",
+      "version": "0.1.1"
     }
   ],
   "gxVersion": "0.9.1",

--- a/psk_conn.go
+++ b/psk_conn.go
@@ -37,14 +37,9 @@ func (c *pskConn) Read(out []byte) (int, error) {
 		c.readS20 = salsa20.New(c.psk, nonce)
 	}
 
-	maxn := uint32(len(out))
-	in := mpool.ByteSlicePool.Get(maxn).([]byte) // get buffer
-	defer mpool.ByteSlicePool.Put(maxn, in)      // put the buffer back
-
-	in = in[:maxn]            // truncate to required length
-	n, err := c.Conn.Read(in) // read to in
+	n, err := c.Conn.Read(out) // read to in
 	if n > 0 {
-		c.readS20.XORKeyStream(out[:n], in[:n]) // decrypt to out buffer
+		c.readS20.XORKeyStream(out[:n], out[:n]) // decrypt to out buffer
 	}
 	return n, err
 }


### PR DESCRIPTION
It has a nicer interface and we don't even need the rest of the msgio stuff.

Prereq of https://github.com/libp2p/go-msgio/pull/9