### PR TITLE
remove dependency on go-multicodec

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	pathPSKv1  = []byte("/key/swarm/psk/1.0.0/")
+	pathBin    = "/bin/"
 	pathBase16 = "/base16/"
 	pathBase64 = "/base64/"
 )
@@ -51,6 +52,8 @@ func decodeV1PSK(in io.Reader) (*[32]byte, error) {
 		decoder = hex.NewDecoder(reader)
 	case pathBase64:
 		decoder = base64.NewDecoder(base64.StdEncoding, reader)
+	case pathBin:
+		decoder = reader
 	default:
 		return nil, fmt.Errorf("unknown encoding: %s", header)
 	}

--- a/codec.go
+++ b/codec.go
@@ -1,35 +1,63 @@
 package pnet
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
-
-	mc "github.com/multiformats/go-multicodec"
-	bmux "github.com/multiformats/go-multicodec/base/mux"
 )
 
 var (
-	pathPSKv1   = []byte("/key/swarm/psk/1.0.0/")
-	headerPSKv1 = mc.Header(pathPSKv1)
+	pathPSKv1  = []byte("/key/swarm/psk/1.0.0/")
+	pathBase16 = "/base16/"
+	pathBase64 = "/base64/"
 )
 
-func decodeV1PSK(in io.Reader) (*[32]byte, error) {
-	var err error
-	in, err = mc.WrapTransformPathToHeader(in)
+func readHeader(r *bufio.Reader) ([]byte, error) {
+	header, err := r.ReadBytes('\n')
 	if err != nil {
 		return nil, err
 	}
-	err = mc.ConsumeHeader(in, headerPSKv1)
+
+	return bytes.TrimRight(header, "\r\n"), nil
+}
+
+func expectHeader(r *bufio.Reader, expected []byte) error {
+	header, err := readHeader(r)
 	if err != nil {
-		return nil, fmt.Errorf("psk header error: %s", err.Error())
+		return err
+	}
+	if !bytes.Equal(header, expected) {
+		return fmt.Errorf("expected file header %s, got: %s", pathPSKv1, header)
+	}
+	return nil
+}
+
+func decodeV1PSK(in io.Reader) (*[32]byte, error) {
+	reader := bufio.NewReader(in)
+	if err := expectHeader(reader, pathPSKv1); err != nil {
+		return nil, err
+	}
+	header, err := readHeader(reader)
+	if err != nil {
+		return nil, err
 	}
 
-	in, err = mc.WrapTransformPathToHeader(in)
-	if err != nil {
-		return nil, fmt.Errorf("wrapping error: %s", err.Error())
+	var decoder io.Reader
+	switch string(header) {
+	case pathBase16:
+		decoder = hex.NewDecoder(reader)
+	case pathBase64:
+		decoder = base64.NewDecoder(base64.StdEncoding, reader)
+	default:
+		return nil, fmt.Errorf("unknown encoding: %s", header)
 	}
-	out := [32]byte{}
-
-	err = bmux.AllBasesMux().Decoder(in).Decode(out[:])
-	return &out, err
+	out := new([32]byte)
+	_, err = io.ReadFull(decoder, out[:])
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }

--- a/codec_test.go
+++ b/codec_test.go
@@ -6,18 +6,29 @@ import (
 	"testing"
 )
 
-func bufWithBase(base string) *bytes.Buffer {
+func bufWithBase(base string, windows bool) *bytes.Buffer {
 
 	b := &bytes.Buffer{}
 	b.Write(pathPSKv1)
+	if windows {
+		b.WriteString("\r")
+	}
 	b.WriteString("\n")
 	b.WriteString(base)
+	if windows {
+		b.WriteString("\r")
+	}
 	b.WriteString("\n")
 	return b
 }
 
 func TestDecodeHex(t *testing.T) {
-	b := bufWithBase("/base16/")
+	testDecodeHex(t, true)
+	testDecodeHex(t, false)
+}
+
+func testDecodeHex(t *testing.T, windows bool) {
+	b := bufWithBase("/base16/", windows)
 	for i := 0; i < 32; i++ {
 		b.WriteString("FF")
 	}
@@ -35,7 +46,12 @@ func TestDecodeHex(t *testing.T) {
 }
 
 func TestDecodeB64(t *testing.T) {
-	b := bufWithBase("/base64/")
+	testDecodeB64(t, true)
+	testDecodeB64(t, false)
+}
+
+func testDecodeB64(t *testing.T, windows bool) {
+	b := bufWithBase("/base64/", windows)
 	key := make([]byte, 32)
 	for i := 0; i < 32; i++ {
 		key[i] = byte(i)

--- a/codec_test.go
+++ b/codec_test.go
@@ -46,6 +46,10 @@ func TestDecodeB64(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = e.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	psk, err := decodeV1PSK(b)
 	if err != nil {

--- a/codec_test.go
+++ b/codec_test.go
@@ -31,6 +31,7 @@ func TestDecodeBad(t *testing.T) {
 	testDecodeBad(t, true)
 	testDecodeBad(t, false)
 }
+
 func testDecodeBad(t *testing.T, windows bool) {
 	b := bufWithBase("/verybadbase/", windows)
 	b.WriteString("Have fun decoding that key")
@@ -80,6 +81,33 @@ func testDecodeB64(t *testing.T, windows bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	psk, err := decodeV1PSK(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, b := range psk {
+		if b != psk[i] {
+			t.Fatal("byte was wrong")
+		}
+	}
+
+}
+
+func TestDecodeBin(t *testing.T) {
+	testDecodeBin(t, true)
+	testDecodeBin(t, false)
+}
+
+func testDecodeBin(t *testing.T, windows bool) {
+	b := bufWithBase("/bin/", windows)
+	key := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		key[i] = byte(i)
+	}
+
+	b.Write(key)
 
 	psk, err := decodeV1PSK(b)
 	if err != nil {

--- a/codec_test.go
+++ b/codec_test.go
@@ -27,6 +27,20 @@ func TestDecodeHex(t *testing.T) {
 	testDecodeHex(t, false)
 }
 
+func TestDecodeBad(t *testing.T) {
+	testDecodeBad(t, true)
+	testDecodeBad(t, false)
+}
+func testDecodeBad(t *testing.T, windows bool) {
+	b := bufWithBase("/verybadbase/", windows)
+	b.WriteString("Have fun decoding that key")
+
+	_, err := decodeV1PSK(b)
+	if err == nil {
+		t.Fatal("expected 'unknown encoding' got nil")
+	}
+}
+
 func testDecodeHex(t *testing.T, windows bool) {
 	b := bufWithBase("/base16/", windows)
 	for i := 0; i < 32; i++ {

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,5 @@ require (
 	github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018
 	github.com/libp2p/go-buffer-pool v0.0.1
 	github.com/libp2p/go-libp2p-interface-pnet v0.0.1
-	github.com/libp2p/go-msgio v0.0.1 // indirect
-	github.com/multiformats/go-multicodec v0.1.6
-	github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 // indirect
 	golang.org/x/crypto v0.0.0-20190228161510-8dd112bcdc25
 )

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,6 @@ github.com/libp2p/go-buffer-pool v0.0.1 h1:9Rrn/H46cXjaA2HQ5Y8lyhOS1NhTkZ4yuEs2r
 github.com/libp2p/go-buffer-pool v0.0.1/go.mod h1:xtyIz9PMobb13WaxR6Zo1Pd1zXJKYg0a8KiIvDp3TzQ=
 github.com/libp2p/go-libp2p-interface-pnet v0.0.1 h1:7GnzRrBTJHEsofi1ahFdPN9Si6skwXQE9UqR2S+Pkh8=
 github.com/libp2p/go-libp2p-interface-pnet v0.0.1/go.mod h1:el9jHpQAXK5dnTpKA4yfCNBZXvrzdOU75zz+C6ryp3k=
-github.com/libp2p/go-msgio v0.0.1 h1:znj97n5FtXGCLDwe9x8jpHmY770SW4WStBGcCDh6GJw=
-github.com/libp2p/go-msgio v0.0.1/go.mod h1:63lBBgOTDKQL6EWazRMCwXsEeEeK9O2Cd+0+6OOuipQ=
-github.com/multiformats/go-multicodec v0.1.6 h1:4u6lcjbE4VVVoigU4QJSSVYsGVP4j2jtDkR8lPwOrLE=
-github.com/multiformats/go-multicodec v0.1.6/go.mod h1:lliaRHbcG8q33yf4Ot9BGD7JqR/Za9HE7HTyVyKwrUQ=
-github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 h1:5HZfQkwe0mIfyDmc1Em5GqlNRzcdtlv4HTNmdpt7XH0=
-github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11/go.mod h1:Wlo/SzPmxVp6vXpGt/zaXhHH0fn4IxgqZc82aKg6bpQ=
 golang.org/x/crypto v0.0.0-20190228161510-8dd112bcdc25 h1:jsG6UpNLt9iAsb0S2AGW28DveNzzgmbXR+ENoPjUeIU=
 golang.org/x/crypto v0.0.0-20190228161510-8dd112bcdc25/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=


### PR DESCRIPTION
It's unmaintained and pulls in github.com/whyrusleeping/cbor. This patch explicitly re-implements the minimally needed features.

Also fixes #12.